### PR TITLE
add sanitize_string function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 ### Added
-- `sanitize_string` function
+- `sanitize_uclahs_cds_id` function
 - Functional testing framework with concrete tests for `methods.set_env()`
 - Functional test for `bam_parser.parse_bam_header()`.
 - Dump parameters with `json_extractor.store_params_json()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 ### Added
+- `sanitize_string` function
 - Functional testing framework with concrete tests for `methods.set_env()`
 - Functional test for `bam_parser.parse_bam_header()`.
 - Dump parameters with `json_extractor.store_params_json()`

--- a/config/methods/README.md
+++ b/config/methods/README.md
@@ -38,7 +38,7 @@ To use a common `methods` function:
 - `set_env` - Function to set the workDir depending on parameters and on Slurm job ID
 - `setup_docker_cpus` - Function to use allocated CPUs for a process to specify number of CPUs rather than CPU shares with Docker
 - `get_absolute_path` - Function to resolve a path relative to the currently-loading configuration file into an absolute path
-- `sanitize_string` - Pass input string to sanitize, i.e. keeping only alphanumeric, `-`, `/`, and `.` characters and replacing `_` with `-`
+- `sanitize_uclahs_cds_id` - Pass input string to sanitize, i.e. keeping only alphanumeric, `-`, `/`, and `.` characters and replacing `_` with `-`
 
 ## Example
 

--- a/config/methods/README.md
+++ b/config/methods/README.md
@@ -38,6 +38,7 @@ To use a common `methods` function:
 - `set_env` - Function to set the workDir depending on parameters and on Slurm job ID
 - `setup_docker_cpus` - Function to use allocated CPUs for a process to specify number of CPUs rather than CPU shares with Docker
 - `get_absolute_path` - Function to resolve a path relative to the currently-loading configuration file into an absolute path
+- `sanitize_string` - Pass input string to sanitize, i.e. keeping only alphanumeric, `-`, `/`, and `.` characters and replacing `_` with `-`
 
 ## Example
 

--- a/config/methods/README.md
+++ b/config/methods/README.md
@@ -141,6 +141,15 @@ methods {
     output_dir = methods.get_absolute_path('../local_outputs')
 }
 ```
+### Sanitize uclahs-cds ID
+```Nextflow
+includeConfig "/path/to/common_methods.config"
+...
+methods {
+    ...
+    new_sm_tag = methods.sanitize_uclahs_cds_id(sm_tags[0])
+}
+```
 
 ## References
 1. `nf-core` - https://nf-co.re/

--- a/config/methods/common_methods.config
+++ b/config/methods/common_methods.config
@@ -344,6 +344,18 @@ methods {
             }
         }
     }
+    
+    /**
+    *   Keep only allowed characters in a string, usually a sample or patient ID
+    */
+    sanitize_string = { raw ->
+        if (![String, GString].any{ raw in it }) {
+            throw new Exception("Input to sanitize is either empty or not a string! Provide a non-empty string.")
+            }
+        def disallowed_characters = /[^a-zA-Z\d\/_.-]/
+        return raw.replaceAll(disallowed_characters, '').replace('_', '-')
+    }
+
 
     /**
     *   Set up Docker to use the cpus allocated to a process as number of CPUs and not CPU share

--- a/config/methods/common_methods.config
+++ b/config/methods/common_methods.config
@@ -348,7 +348,7 @@ methods {
     /**
     *   Keep only allowed characters in a string, usually a sample or patient ID
     */
-    sanitize_string = { raw ->
+    sanitize_uclahs_cds_id = { raw ->
         if (![String, GString].any{ raw in it }) {
             throw new Exception("Input to sanitize is either empty or not a string! Provide a non-empty string.")
             }


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [x] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the config being added or modified. Outline the tests below.

Added the `sanitize_string` function to `common_methods`.  

### Testing
      
 Tested in `pipeline-SQC-DNA` with local function removed (branch `sfitz-use-sanitize-from-common`)
output: `/hot/software/pipeline/pipeline-SQC-DNA/Nextflow/development/unreleased/sfitz-use-sanitize-from-common/a_mini_n2-std-input-default`
log: `/hot/software/pipeline/pipeline-SQC-DNA/Nextflow/development/unreleased/sfitz-use-sanitize-from-common/slurm-85433.out`
