### PR TITLE
Use params in `set_resources_allocation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 - Fixed retry for potentially undefined variable `proc_name_keys`. #57
 
+### Changed
+- Allow `set_resources_allocation` to use maximum allocation values defined in params
+
 ---
 
 ## [1.2.0] - 2023-10-06

--- a/config/methods/common_methods.config
+++ b/config/methods/common_methods.config
@@ -14,10 +14,33 @@ methods {
     *   Detect and load base and node-specific resource allocations
     *   @throws IllegalStateException if system resources are not as expected.
     *   @throws java.nio.file.NoSuchFileException if there is no config file for the partition type.
+    *   @throws NumberFormatException if invalid number provided for max_cpus.
+    *   @throws IllegalArgumentException if invalid memory provided for max_memory or if max_cpus is less than 1.
     */
     set_resources_allocation = {
-        def node_cpus = SysHelper.getAvailCpus()
-        def node_memory_GB = SysHelper.getAvailMemory().toGiga()
+        def node_cpus = (params.containsKey('max_cpus')) ? params.max_cpus : SysHelper.getAvailCpus()
+        try {
+            node_cpus = node_cpus as Integer
+        } catch(NumberFormatException number_format_exception) {
+            System.out.println("     ### ERROR ###     Invalid format for params.max_cpus: `${node_cpus}`, please provide an integer.")
+            throw number_format_exception
+        }
+
+        if (node_cpus < 1) {
+            throw new IllegalArgumentException("params.max_cpus = `${node_cpus}` cannot be less than 1.")
+        }
+
+        def node_memory = (params.containsKey('max_memory')) ? params.max_memory : SysHelper.getAvailMemory()
+
+        try {
+            node_memory = node_memory as nextflow.util.MemoryUnit
+        } catch(IllegalArgumentException illegal_argument_exception) {
+            System.out.println("     ### ERROR ###     Invalid memory value specified for params.max_memory: `${node_memory}`, please provide an valid memory unit value.")
+            throw illegal_argument_exception
+        }
+
+        def node_memory_GB = node_memory.toGiga()
+
         // Load base.config by default for all pipelines
         includeConfig "${projectDir}/config/base.config"
         def config_to_include = ""


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [X] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [X] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [X] I have tested the config being added or modified. Outline the tests below.

<!--- Briefly describe the changes included in this pull request and the paths to the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Tested with `/hot/software/pipeline/pipeline-Nextflow-config/Nextflow/development/unreleased/yashpatel-use-params-resource-allocations/main.nf`
Log: `/hot/software/pipeline/pipeline-Nextflow-config/Nextflow/development/unreleased/yashpatel-use-params-resource-allocations/run.log`