### PR TITLE
Add defs to incorrectly-global variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 - Allow `set_resources_allocation` to use maximum allocation values defined in params
+- Add `def`s to multiple variables that should not be globally defined
 
 ---
 

--- a/config/retry/retry.config
+++ b/config/retry/retry.config
@@ -29,7 +29,7 @@ retry {
         def proc_params = [:]
         for (i in process) {
             if (i.key.startsWith('withName:')) {
-                proc_names = i.key.split('withName:')[1].split("\\|")
+                def proc_names = i.key.split('withName:')[1].split("\\|")
                 for (proc_name in proc_names) {
                     proc_params = [:]
                     for (j in i.value) {

--- a/config/schema/schema.config
+++ b/config/schema/schema.config
@@ -25,7 +25,7 @@ schema {
     load_schema = { String file_path ->
         def schema_file = new File(file_path)
         Yaml parser = new Yaml()
-        yaml = parser.load(schema_file.text)
+        def yaml = parser.load(schema_file.text)
         return yaml
     }
 
@@ -244,7 +244,7 @@ schema {
     * Main validation to call, to validate the params from config file(s) against the schema.
     */
     validate = { String file_path="${projectDir}/config/schema.yaml" ->
-        params_schema = schema.load_schema(file_path)
+        def params_schema = schema.load_schema(file_path)
         params_schema.each { key, val ->
             schema.validate_parameter(params, key, val)
         }
@@ -257,7 +257,7 @@ schema {
     * keys_to_exclude: params to skip during validation
     */
     validate_specific = { String file_path, Map params_to_validate, List keys_to_exclude=[] ->
-        params_schema = schema.load_schema(file_path)
+        def params_schema = schema.load_schema(file_path)
         params_schema.removeAll{ key, val -> keys_to_exclude.contains(key) }
         params_schema.each { key, val ->
             schema.validate_parameter(params_to_validate, key, val)


### PR DESCRIPTION
This adds `def`s to several variables that should not be global. These changes eliminate 375 lines from each of the pipeline-recalibrate-BAM [test cases](https://github.com/uclahs-cds/pipeline-recalibrate-BAM/tree/c37a673915b121ba2f6ab52aef1f2b5b12d7ce8c/test), or 47% of the total lines!

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [x] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the config being added or modified. Outline the tests below.

