### PR TITLE
Add more options for specific validation function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 - Allow `set_resources_allocation` to use maximum allocation values defined in params
 - Add `def`s to multiple variables that should not be globally defined
+- Allow specific schema validation function to accept pre-loaded schema as input
 
 ---
 

--- a/config/schema/README.md
+++ b/config/schema/README.md
@@ -93,7 +93,7 @@ input:
     - Positional args:
         |position|name|type|required|default|description|
         |:--:|:--:|:--:|:--:|:--:|:--:|
-        |1|`file_path`|String|Yes|none|Path to the `schema.yaml` file|
+        |1|`file_path`|String or Map|Yes|none|Path to the `schema.yaml` file or loaded schema as a Map|
         |2|`params_to_validate`|Map|Yes|none|Namespace of parameters to validate|
         |3|`keys_to_exclude`|List|No|`[]`|List of parameters to skip validation|
 

--- a/config/schema/schema.config
+++ b/config/schema/schema.config
@@ -1,4 +1,5 @@
 import org.yaml.snakeyaml.Yaml
+includeConfig "./custom_schema_types.config"
 /**
 * This schema namespace is used to valide the params defined in config file(s) using a schema
 * YAML file. This config script should be included and called through `schema.validate()` at the
@@ -252,12 +253,21 @@ schema {
 
     /**
     * Fine-grained validation entrypoint; to be used for validating specific namespaces with certain parameters excluded
-    * file_path: path to schema YAML to be used for validation
+    * schema_to_validate: path to schema YAML to be used for validation
     * params_to_validate: Map of parameters to validate against schema
     * keys_to_exclude: params to skip during validation
+    * @throws IllegalArgumentException when invalid format of schema is provided
     */
-    validate_specific = { String file_path, Map params_to_validate, List keys_to_exclude=[] ->
-        def params_schema = schema.load_schema(file_path)
+    validate_specific = { Object schema_to_validate, Map params_to_validate, List keys_to_exclude=[] ->
+        def params_schema;
+        if (custom_schema_types.is_string(schema_to_validate)) {
+            params_schema = schema.load_schema(schema_to_validate)
+        } else if (schema_to_validate in Map) {
+            params_schema = schema_to_validate
+        } else {
+            throw new IllegalArgumentException("The given schema must be a path to the schema YAML or a Map, received `${schema_to_validate.getClass()}` instead.")
+        }
+
         params_schema.removeAll{ key, val -> keys_to_exclude.contains(key) }
         params_schema.each { key, val ->
             schema.validate_parameter(params_to_validate, key, val)


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [X] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [X] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [X] I have tested the config being added or modified. Outline the tests below.

<!--- Briefly describe the changes included in this pull request and the paths to the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Updating the specific validation function to accept either a path to `schema.yaml` or the result of loading the schema into a Map. Used in cases where the schema needs to be modified depending on certain parameters to disable/enable certain parameters prior to validation. Tested with metapipeline-DNA at https://github.com/uclahs-cds/metapipeline-DNA/pull/194
