### PR TITLE
Fix schema to handle error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 - Fixed retry for potentially undefined variable `proc_name_keys`. #57
+- Fix `schema.check_write_permission` when `null` is returned by `getParentFile` #59
 
 ### Changed
 - Allow `set_resources_allocation` to use maximum allocation values defined in params
 - Add `def`s to multiple variables that should not be globally defined
 - Allow specific schema validation function to accept pre-loaded schema as input
+- Add try-catch to schema validation to log the parameter being failed to validate.
 
 ---
 

--- a/config/schema/schema.config
+++ b/config/schema/schema.config
@@ -56,7 +56,7 @@ schema {
     */
     check_path = { String p, String mode ->
         def File file = new File(p)
-        file = file.absolutePath()
+        file = file.getAbsolutePath()
         if (mode == 'w') {
             schema.check_write_permission(file)
             return

--- a/config/schema/schema.config
+++ b/config/schema/schema.config
@@ -56,7 +56,7 @@ schema {
     */
     check_path = { String p, String mode ->
         def File file = new File(p)
-        file = file.getAbsolutePath()
+        file = new File(file.getAbsolutePath())
         if (mode == 'w') {
             schema.check_write_permission(file)
             return

--- a/config/schema/schema.config
+++ b/config/schema/schema.config
@@ -56,6 +56,7 @@ schema {
     */
     check_path = { String p, String mode ->
         def File file = new File(p)
+        file = file.absolutePath()
         if (mode == 'w') {
             schema.check_write_permission(file)
             return
@@ -92,7 +93,7 @@ schema {
     /**
     * Check whether the required properties are defined for the corresponding parameter from the
     * schema yaml file.
-    * 
+    *
     * @throws IllegalArgumentException when config file is missing required properties.
     */
     check_required_properties = { String name, Map properties ->
@@ -247,7 +248,12 @@ schema {
     validate = { String file_path="${projectDir}/config/schema.yaml" ->
         def params_schema = schema.load_schema(file_path)
         params_schema.each { key, val ->
-            schema.validate_parameter(params, key, val)
+            try {
+                schema.validate_parameter(params, key, val)
+            } catch (Exception ex) {
+                System.out.println "Failed to validate parameter key: ${val}"
+                throw ex
+            }
         }
     }
 

--- a/config/schema/schema.config
+++ b/config/schema/schema.config
@@ -56,7 +56,7 @@ schema {
     */
     check_path = { String p, String mode ->
         def File file = new File(p)
-        file = new File(file.getAbsolutePath())
+        file = file.getAbsoluteFile()
         if (mode == 'w') {
             schema.check_write_permission(file)
             return


### PR DESCRIPTION
1. In `schema.check_path`, if the directory is relative, and the directory doesn't exist, it will try to call `getParentFile` until it becomes `null`  and failed with the error of `no exists() method for null object`. So I turned the path to an absolute path.
2. Also added a try catch block to print what parameter that causes an error, which can save a lot of time for debugging.

<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [ ] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [ ] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [ ] I have tested the config being added or modified. Outline the tests below.

<!--- Briefly describe the changes included in this pull request and the paths to the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Closes #59
