### PR TITLE
Generalize function for checking list of readable files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `def`s to multiple variables that should not be globally defined
 - Allow specific schema validation function to accept pre-loaded schema as input
 - Add try-catch to schema validation to log the parameter being failed to validate.
+- Rename `check_bam_list` function to more general `check_readable_file_list`
 
 ---
 

--- a/config/schema/custom_schema_types.config
+++ b/config/schema/custom_schema_types.config
@@ -89,9 +89,9 @@ custom_schema_types {
     }
 
     /**
-    * Check if proper BAM entry list
+    * Check if list of readable files
     */
-    check_bam_list = { Map options, String name, Map properties ->
+    check_readable_file_list = { Map options, String name, Map properties ->
         custom_schema_types.check_if_list(options[name], name)
         for (item in options[name]) {
             schema.check_path(item, 'r')
@@ -118,6 +118,6 @@ custom_schema_types {
         'InputNamespace': custom_schema_types.check_input_namespace,
         'ListFASTQPairs': custom_schema_types.check_list_of_namespace,
         'InputBAMNamespace': custom_schema_types.check_bam_namespace,
-        'BAMEntryList': custom_schema_types.check_bam_list
+        'BAMEntryList': custom_schema_types.check_readable_file_list
     ]
 }

--- a/config/schema/custom_schema_types.config
+++ b/config/schema/custom_schema_types.config
@@ -119,5 +119,6 @@ custom_schema_types {
         'ListFASTQPairs': custom_schema_types.check_list_of_namespace,
         'InputBAMNamespace': custom_schema_types.check_bam_namespace,
         'BAMEntryList': custom_schema_types.check_readable_file_list
+        'ReadableFileList': custom_schema_types.check_readable_file_list
     ]
 }

--- a/config/schema/custom_schema_types.config
+++ b/config/schema/custom_schema_types.config
@@ -118,7 +118,7 @@ custom_schema_types {
         'InputNamespace': custom_schema_types.check_input_namespace,
         'ListFASTQPairs': custom_schema_types.check_list_of_namespace,
         'InputBAMNamespace': custom_schema_types.check_bam_namespace,
-        'BAMEntryList': custom_schema_types.check_readable_file_list
+        'BAMEntryList': custom_schema_types.check_readable_file_list,
         'ReadableFileList': custom_schema_types.check_readable_file_list
     ]
 }


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [X] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [X] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [ ] I have tested the config being added or modified. Outline the tests below.

<!--- Briefly describe the changes included in this pull request and the paths to the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Renaming a function to be more generic and adding a general type to use that function