### PR TITLE
Add GString to acceptable schema types for 'Path'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `def`s to multiple variables that should not be globally defined
 - Allow specific schema validation function to accept pre-loaded schema as input
 - Add try-catch to schema validation to log the parameter being failed to validate.
+- Allow Path schema type to be a GString
 
 ---
 

--- a/config/schema/schema.config
+++ b/config/schema/schema.config
@@ -13,7 +13,7 @@ schema {
         'List'     : List,
         'Bool'     : Boolean,
         'Namespace': Map,
-        'Path'     : String
+        'Path'     : [String, GString]
     ]
     required_properties = ['type']
     path_types = ['Path']

--- a/config/schema/schema.config
+++ b/config/schema/schema.config
@@ -136,7 +136,7 @@ schema {
     */
     primitive_check_type = { Map options, String name, String type ->
         if (!(schema.type_map[type].any{ options[name] in it })) {
-            throw new IllegalStateException("Invalid parameter type for parameter ${name}. Requires ${schema.type_map[type]} but received ${val.getClass()}.")
+            throw new IllegalStateException("Invalid parameter type for parameter ${name}. Requires ${schema.type_map[type]} but received ${options[name].getClass()}.")
         }
         return true
     }


### PR DESCRIPTION
This is a simple change that allows "Path"-type parameters to be groovy strings. That's exactly in-line with the "String"-type parameters and allows us to do things like this:

```nextflow
params {
    reference_fasta_fai = "${-> params.reference_fasta}.fai"
}
```

When I add that to the schema...
```yaml
reference_fasta_fai:
  type: 'Path'
  mode: 'r'
  required: true
  help: 'Absolute path to reference genome fasta index file'
```

... and mangle the filepath, it correctly validates the _lack_ of that file:

```console
ERROR ~ Unable to parse config file: '/hot/code/nwiltsie/pipelines/pipeline-recalibrate-BAM/test/nftest.config'

  /hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta.MANGLEDfai does not exist.
```

I also fixed a bug where errors raised by `schema.primitive_check_type` would always report that the parameter is a ConfigObject, regardless of the actual type.

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the config being added or modified. Outline the tests below.