### PR TITLE
Fix choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,23 +8,28 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ---
 
 ## [Unreleased]
+
+---
+
+## [1.3.0] - 2024-09-04
 ### Added
 - `sanitize_uclahs_cds_id` function
 - Functional testing framework with concrete tests for `methods.set_env()`
-- Functional test for `bam_parser.parse_bam_header()`.
+- Functional test for `bam_parser.parse_bam_header()`
 - Dump parameters with `json_extractor.store_params_json()`
 - Option to allow empty fields in a CSV to be parsed without error
 - Function to save process logs, even after failure
 
 ### Fixed
-- Fixed retry for potentially undefined variable `proc_name_keys`. #57
+- Fix retry for potentially undefined variable `proc_name_keys` #57
 - Fix `schema.check_write_permission` when `null` is returned by `getParentFile` #59
+- Fix checking of `choices` to properly check choices when given
 
 ### Changed
 - Allow `set_resources_allocation` to use maximum allocation values defined in params
 - Add `def`s to multiple variables that should not be globally defined
 - Allow specific schema validation function to accept pre-loaded schema as input
-- Add try-catch to schema validation to log the parameter being failed to validate.
+- Add try-catch to schema validation to log the parameter being failed to validate
 - Rename `check_bam_list` function to more general `check_readable_file_list`
 - Allow Path schema type to be a GString
 

--- a/config/schema/schema.config
+++ b/config/schema/schema.config
@@ -19,6 +19,12 @@ schema {
     path_types = ['Path']
     custom_types = [:]
 
+    single_choice_types = [
+        'String',
+        'Path',
+        'Number',
+        'Integer'
+    ]
 
     /**
     * Load the schema file.
@@ -209,6 +215,10 @@ schema {
             } else if (schema.custom_types.containsKey(properties.type)) {
                 schema.custom_types[properties.type](options, name, properties)
             } else if (properties.containsKey('choices')) {
+                schema.check_choices_singular(options, name, properties.choices)
+            }
+
+            if (properties.type in schema.single_choice_types && properties.containsKey('choices')) {
                 schema.check_choices_singular(options, name, properties.choices)
             }
         } else {

--- a/config/schema/schema.config
+++ b/config/schema/schema.config
@@ -214,8 +214,6 @@ schema {
                 schema.check_path(options[name], properties.mode)
             } else if (schema.custom_types.containsKey(properties.type)) {
                 schema.custom_types[properties.type](options, name, properties)
-            } else if (properties.containsKey('choices')) {
-                schema.check_choices_singular(options, name, properties.choices)
             }
 
             if (properties.type in schema.single_choice_types && properties.containsKey('choices')) {


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [X] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [X] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [X] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [X] I have tested the config being added or modified. Outline the tests below.

<!--- Briefly describe the changes included in this pull request and the paths to the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Adding fix to properly check choices when given.

Tested:
`/hot/software/pipeline/pipeline-Nextflow-config/Nextflow/development/unreleased/yashpatel-fix-choices/current.log` - Parameter passes validation with a value that's not in the choices
`/hot/software/pipeline/pipeline-Nextflow-config/Nextflow/development/unreleased/yashpatel-fix-choices/fixed.log` - Parameter properly caught during validation