### PR TITLE
Update cluster reference paths

### DIFF
--- a/config/methods/README.md
+++ b/config/methods/README.md
@@ -83,7 +83,7 @@ includeConfig "/path/to/common_methods.config"
 ...
 methods {
     ...
-    genome_version = methods.get_genome_version("/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta")
+    genome_version = methods.get_genome_version("/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta")
 }
 ```
 

--- a/config/methods/common_methods.config
+++ b/config/methods/common_methods.config
@@ -181,7 +181,7 @@ methods {
         } catch (Exception e) {
             throw new IllegalArgumentException("     ### ERROR ###     Failed to resolve genome path: ${genome_path}")
         }
-        def pattern = ~/^\/hot\/ref\/reference\/(?<genomeversion>[A-Za-z0-9-]+)\/.+$/
+        def pattern = ~/^\/hot\/resource\/reference-genome\/(?<genomeversion>[A-Za-z0-9-]+)\/.+$/
         def matcher = genome_real_path =~ pattern
         matcher.matches()
         try {

--- a/config/methods/common_methods.config
+++ b/config/methods/common_methods.config
@@ -187,7 +187,7 @@ methods {
         try {
             return matcher.group("genomeversion")
         } catch (Exception e) {
-            throw new IllegalArgumentException("     ### ERROR ###     Failed to extract genome version: ${genome_real_path}. Expected path to follow UCLA CDS reference format: /hot/ref/reference/<genome_version>/...")
+            throw new IllegalArgumentException("     ### ERROR ###     Failed to extract genome version: ${genome_real_path}. Expected path to follow UCLA CDS reference format: /hot/resource/reference-genome/<genome_version>/...")
         }
     }
 


### PR DESCRIPTION
This PR updates reference paths that were renamed during the most recent cluster downtime.

I was specifically looking for single lines containing one (or more) of the following keys, so I missed any paths split across multiple lines.

| Search String                                                  |
|----------------------------------------------------------------|
| `/hot/ref/`                                                    |
| `/hot/ref/cohort/TCGA/CCG-AIM/`                                |
| `/hot/ref/cohort/TCGA/PanCanAtlas/`                            |
| `/hot/ref/database/1000Genomes/`                               |
| `/hot/ref/database/GDC-34.0 `                                  |
| `/hot/ref/database/GDC-34.0/`                                  |
| `/hot/ref/database/PCAWG/`                                     |
| `/hot/ref/database/ProstateTumor/Boutros-Yamaguchi-PRAD-CPCG/` |
| `/hot/ref/reference/`                                          |
| `/hot/resource/SMC-HET/`                                       |

A table of updated filepaths and whether or not they resolve to a file is included below. Where the original paths still exist due to symlinks I verified that they resolve to the same file as the updated path.

| Original                                                              |                    | Updated                                                                           |                    |
|-----------------------------------------------------------------------|--------------------|-----------------------------------------------------------------------------------|--------------------|
| `/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta` | :white_check_mark: | `/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta` | :white_check_mark: |
| `/hot/ref/reference/<genome_version>/...`                             | :white_circle:     | `/hot/resource/reference-genome/<genome_version>/...`                             | :white_circle:     |
